### PR TITLE
GPL v2 does not permit this sort of restriction

### DIFF
--- a/README
+++ b/README
@@ -3,7 +3,6 @@
 Copyright (C) 2002-2014 Rob Versluis, Rocrail.net
 
 Without an official permission commercial use is not permitted.
-Forking this project is not permitted.  
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License


### PR DESCRIPTION
This line of the README contradicts the license that the source code is under, vis:

> 1. You may copy and distribute verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and give any other recipients of the Program a copy of this License along with the Program.
>
> 2. You may modify your copy or copies of the Program or any portion of it, thus forming a work based on the Program, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:

Please update the README to remove this restriction, or re-license to something compatible with these constraints (with the permission of all contributors).

I wanted to open an issue for the commentary above, but that was disabled in the repository so I suggested this edit instead. GitHub automatically forks the repository to allow this feature. My actions are not intended to be counter to the wishes expressed in the file, but seemed to be the only way to open a dialog about this confusing restriction.